### PR TITLE
elasticsearch: Use parallel pod management policy

### DIFF
--- a/pkg/controllers/elasticsearch/nodepool/resources.go
+++ b/pkg/controllers/elasticsearch/nodepool/resources.go
@@ -52,7 +52,8 @@ func nodePoolStatefulSet(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.Elastics
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{
 				Type: apps.RollingUpdateStatefulSetStrategyType,
 			},
-			Template: *elasticsearchPodTemplate,
+			PodManagementPolicy: apps.ParallelPodManagement,
+			Template:            *elasticsearchPodTemplate,
 		},
 	}
 


### PR DESCRIPTION
Without this change, if a node comes up without other nodes being ready (e.g. because it's the first node), the readiness probe does not pass and so the scale up doesn't proceed.

In future we should improve the readiness probe to be more away of this situation.